### PR TITLE
chore: upgrade to latest @bosonprotocol/agentic-commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ ANTHROPIC_API_KEY=your_anthropic_key_here
 OPENAI_API_KEY=your_openai_key_here
 
 # Boson Protocol
-BOSON_MCP_URL=https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp
+BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
 
 # Platform-specific
 TG_BOT_TOKEN=your_telegram_bot_token           # For Telegram examples

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "src/examples/xmtp"
       ],
       "dependencies": {
-        "@bosonprotocol/agentic-commerce": "1.2.3",
+        "@bosonprotocol/agentic-commerce": "^1.2.4",
         "@bosonprotocol/chat-sdk": "1.4.5",
         "@bosonprotocol/common": "1.32.2",
         "dotenv": "^17.2.1",
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/@bosonprotocol/agentic-commerce": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/agentic-commerce/-/agentic-commerce-1.2.3.tgz",
-      "integrity": "sha512-Tm7QblcXQIaZ5DZJ1ZQunQdzXepK5qN8QZvQC8DVfc4tIOmk7BidrQIOtj+Sx+jaujTy0liEXWSdVr0ROPW7Lg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/agentic-commerce/-/agentic-commerce-1.2.4.tgz",
+      "integrity": "sha512-i1SooJydzf7JNQ4rarRsY0rMzgLTvHfUBZibDlN9ymin5QVxe0GM+Drs5eSaMTuI7zPURGX3Do9+7Z/bwvhwqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -437,7 +437,7 @@
         "boson-mcp-server": "dist/boson/mcp-server/index.js"
       },
       "engines": {
-        "node": ">=23.11.1"
+        "node": ">=20.12.2"
       }
     },
     "node_modules/@bosonprotocol/agentic-commerce/node_modules/@bosonprotocol/common": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "agent-builder",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "workspaces": [
         "src/examples/standalone/vercel",
         "src/examples/standalone/langchain",
@@ -16,7 +16,7 @@
         "src/examples/xmtp"
       ],
       "dependencies": {
-        "@bosonprotocol/agentic-commerce": "^1.2.4",
+        "@bosonprotocol/agentic-commerce": "1.2.5",
         "@bosonprotocol/chat-sdk": "1.4.5",
         "@bosonprotocol/common": "1.32.2",
         "dotenv": "^17.2.1",
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/@bosonprotocol/agentic-commerce": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@bosonprotocol/agentic-commerce/-/agentic-commerce-1.2.4.tgz",
-      "integrity": "sha512-i1SooJydzf7JNQ4rarRsY0rMzgLTvHfUBZibDlN9ymin5QVxe0GM+Drs5eSaMTuI7zPURGX3Do9+7Z/bwvhwqQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@bosonprotocol/agentic-commerce/-/agentic-commerce-1.2.5.tgz",
+      "integrity": "sha512-wrwn9Bu8AXZ43bWFTSDgTuF8Wo1gwYDDbB1fp73AZhujTVOA/Wm9iLEjiCqYuMQDJaZJLkbOsTOFC4gy5YVMzA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,18 +22,25 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts --fix"
   },
+  "keywords": [
+    "mcp",
+    "boson-protocol",
+    "web3",
+    "commerce",
+    "polygon",
+    "amoy"
+  ],
+  "author": "Boson Protocol",
+  "homepage": "https://bosonprotocol.io",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bosonprotocol/agent-builder.git"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bosonprotocol/agent-builder/issues"
   },
-  "homepage": "https://github.com/bosonprotocol/agent-builder#readme",
-  "description": "",
+  "description": "Reference agents and integration examples for Boson Protocol",
   "overrides": {
     "@ai-sdk/provider": "1.1.3",
     "viem": "2.37.3",
@@ -56,7 +63,7 @@
     "typescript-eslint": "^8.40.0"
   },
   "dependencies": {
-    "@bosonprotocol/agentic-commerce": "^1.2.4",
+    "@bosonprotocol/agentic-commerce": "1.2.5",
     "@bosonprotocol/chat-sdk": "1.4.5",
     "@bosonprotocol/common": "1.32.2",
     "dotenv": "^17.2.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript-eslint": "^8.40.0"
   },
   "dependencies": {
-    "@bosonprotocol/agentic-commerce": "1.2.3",
+    "@bosonprotocol/agentic-commerce": "^1.2.4",
     "@bosonprotocol/chat-sdk": "1.4.5",
     "@bosonprotocol/common": "1.32.2",
     "dotenv": "^17.2.1",

--- a/src/common/chains.ts
+++ b/src/common/chains.ts
@@ -29,10 +29,10 @@ if (
   !isTesting &&
   !isLocal &&
   !isStaging &&
-  !BOSON_MCP_URL?.includes("production")
+  !BOSON_MCP_URL?.includes("mcp.bosonprotocol.io")
 ) {
   throw new Error(
-    "BOSON_MCP_URL must include 'production' for production environment or 'staging' for staging environment",
+    "BOSON_MCP_URL must include 'mcp.bosonprotocol.io' for production environment or 'staging' for staging environment",
   );
 }
 

--- a/src/common/chains.ts
+++ b/src/common/chains.ts
@@ -32,7 +32,7 @@ if (
   !BOSON_MCP_URL?.includes("mcp.bosonprotocol.io")
 ) {
   throw new Error(
-    "BOSON_MCP_URL must include 'mcp.bosonprotocol.io' for production environment or 'staging' for staging environment",
+    "BOSON_MCP_URL must include 'mcp.bosonprotocol.io' for production environment or 'mcp-staging.bosonprotocol.io' for staging environment",
   );
 }
 

--- a/src/examples/email/.env.example
+++ b/src/examples/email/.env.example
@@ -25,9 +25,9 @@ ANTHROPIC_API_KEY=
 # ===============================
 
 # For testing with staging MCP server
-BOSON_MCP_URL=https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp
+BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
 # or this url for production
-# BOSON_MCP_URL=https://boson-mcp-server-production-170470978472.europe-west2.run.app/mcp
+# BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp
 
 
 # ===============================

--- a/src/examples/standalone/langchain/.env.example
+++ b/src/examples/standalone/langchain/.env.example
@@ -25,7 +25,7 @@ ANTHROPIC_API_KEY=
 # ===============================
 
 # For testing with staging MCP server
-BOSON_MCP_URL=https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp
+BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
 # or this url for production
-# BOSON_MCP_URL=https://boson-mcp-server-production-170470978472.europe-west2.run.app/mcp
+# BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp
 

--- a/src/examples/standalone/langchain/README.md
+++ b/src/examples/standalone/langchain/README.md
@@ -43,8 +43,6 @@ npm install
    # Required
    ANTHROPIC_API_KEY=your_anthropic_api_key_here
    CHAIN_ID = chain_id_matching_chainId_from_config
-   
-   # Optional - defaults to staging if not provided
    BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
    
    # Optional - for debugging and tracing

--- a/src/examples/standalone/langchain/README.md
+++ b/src/examples/standalone/langchain/README.md
@@ -45,7 +45,7 @@ npm install
    CHAIN_ID = chain_id_matching_chainId_from_config
    
    # Optional - defaults to staging if not provided
-   BOSON_MCP_URL=https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp
+   BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
    
    # Optional - for debugging and tracing
    LANGSMITH_API_KEY=your_langsmith_key_here

--- a/src/examples/standalone/vercel/.env.example
+++ b/src/examples/standalone/vercel/.env.example
@@ -26,6 +26,6 @@ ANTHROPIC_API_KEY=
 # ===============================
 
 # For testing with staging MCP server
-BOSON_MCP_URL=https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp
+BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
 # or this url for production
-# BOSON_MCP_URL=https://boson-mcp-server-production-170470978472.europe-west2.run.app/mcp
+# BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp

--- a/src/examples/telegram/vercel/.env.example
+++ b/src/examples/telegram/vercel/.env.example
@@ -12,9 +12,9 @@ ANTHROPIC_API_KEY=
 # ===============================
 
 # For testing with staging MCP server
-BOSON_MCP_URL=https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp
+BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
 # or this url for production
-# BOSON_MCP_URL=https://boson-mcp-server-production-170470978472.europe-west2.run.app/mcp
+# BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp
 
 
 # ===============================

--- a/src/examples/telegram/vercel/README.md
+++ b/src/examples/telegram/vercel/README.md
@@ -62,8 +62,6 @@ Create a `.env` file in the example folder:
 # Required
 TG_BOT_TOKEN=your_telegram_bot_token_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
-
-# Optional - MCP server configuration
 BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
 
 # Optional - Environment mode

--- a/src/examples/telegram/vercel/README.md
+++ b/src/examples/telegram/vercel/README.md
@@ -64,7 +64,7 @@ TG_BOT_TOKEN=your_telegram_bot_token_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # Optional - MCP server configuration
-BOSON_MCP_URL=https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp
+BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
 
 # Optional - Environment mode
 NODE_ENV=development

--- a/src/examples/xmtp/.env.example
+++ b/src/examples/xmtp/.env.example
@@ -25,9 +25,9 @@ ANTHROPIC_API_KEY=
 # ===============================
 
 # For testing with staging MCP server
-BOSON_MCP_URL=https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp
+BOSON_MCP_URL=https://mcp-staging.bosonprotocol.io/mcp
 # or this url for production
-# BOSON_MCP_URL=https://boson-mcp-server-production-170470978472.europe-west2.run.app/mcp
+# BOSON_MCP_URL=https://mcp.bosonprotocol.io/mcp
 
 # ===============================
 # 🛠 Boson XMTP MCP Server Config


### PR DESCRIPTION

This pull request updates the Boson MCP server URLs throughout the codebase and documentation to use the new canonical domains, and also improves project metadata and dependencies. The most significant changes are grouped below.

**Boson MCP Server URL Updates:**

* Updated all references of the staging MCP server URL from `https://boson-mcp-server-staging-170470978472.europe-west2.run.app/mcp` to `https://mcp-staging.bosonprotocol.io/mcp` in environment example files and documentation, and updated the production URL accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L138-R138) [[2]](diffhunk://#diff-5f3776339ed527afce25fbb16fd0f2650f6b6d34ca3e545f24fa25aa88bcec6eL28-R30) [[3]](diffhunk://#diff-d5b181076e8dad9d80b258e071b641804e4c22dc06fd403f647d5b3b9e3cd1c6L28-R30) [[4]](diffhunk://#diff-4601a9af82b0028de003d1f11caeb54c838c7773a27dbd2856d8554e63b91c73L46-R46) [[5]](diffhunk://#diff-b8018cf9f65b834d99e9623d6bd3635d1d54fcf05d45903c6bce131da0b86e21L29-R31) [[6]](diffhunk://#diff-661e0056ebf6522df34552c90ffbb533a02e1b0b9673cc2faadb21941d8d1962L15-R17) [[7]](diffhunk://#diff-701e819bb106503e7cc45a3a92ebb84d094b1e3e7dda38f77c1e43ac51356649L65-R65) [[8]](diffhunk://#diff-3477f54be744a19e679f0cd9eaea9653c62d62a6da31704beb72b7fe279550d1L28-R30)
* Modified the validation logic in `src/common/chains.ts` to check for the new MCP domain names for production and staging environments, and updated the error messages to reflect these changes.

**Project Metadata and Dependency Updates:**

* Updated `package.json` with new keywords, author, homepage, and description to better reflect the project and its association with Boson Protocol. Changed the license to `Apache-2.0`.
* Upgraded the `@bosonprotocol/agentic-commerce` dependency from version `1.2.3` to `1.2.5`.